### PR TITLE
Add support to collection of checkboxes

### DIFF
--- a/lib/bootstrap_form.ex
+++ b/lib/bootstrap_form.ex
@@ -24,6 +24,11 @@ defmodule BootstrapForm do
           <%= submit "Submit", classL "btn btn-primary" %>
         <% end %>
 
+  It also supports a collection of checkboxes.
+
+        <%= input(form, :active, type: :collection_checkboxes, collection: [{true, "Yes"}, {false, "No"}]) %>
+        <%= input(form, :colors, type: :collection_checkboxes, collection: ['Red', 'Blue']) %>
+
   See `input/3` for the available options.
   """
 
@@ -49,6 +54,10 @@ defmodule BootstrapForm do
        input.
 
     * `:wrapper_html` - The HTML attributes to the wrapper tag.
+
+    * `:collection` - A list of items to generate multiple checkboxes or radio buttons. Required only
+       for collection_checkboxes and collection_radiobuttons.
+
   """
   def input(form, field_name, options \\ []) do
     {type, options} = Keyword.pop(options, :type)

--- a/lib/bootstrap_form/collection_checkboxes.ex
+++ b/lib/bootstrap_form/collection_checkboxes.ex
@@ -1,0 +1,58 @@
+defmodule BootstrapForm.CollectionCheckboxes do
+  @moduledoc false
+
+  alias BootstrapForm.{Input, Checkbox}
+
+  @behaviour Input
+
+  @doc """
+  Generate a list of bootstrap checkbox input according to the given options.
+
+  ## Custom options
+
+  collection: An array of items that will be used to render the checkboxes.
+
+  This function just interprets the given collection to render a checkbox for each item. See the
+  `Checkbox` module for more info.
+
+  ## Examples
+
+      build(:user, :active, collection: [{true, "Yes"}, {false, "No"}])
+      # => <div class="form-check">
+             <input name="user[active]" type="hidden" value="false">
+             <input class="form-check-input" id="user_active" name="user[active]" type="checkbox" value="true">
+             <label class="form-check-label" for="user_active">Yes</label>
+          </div>
+          <div class="form-check">
+             <input name="user[active]" type="hidden" value="false">
+             <input class="form-check-input" id="user_active" name="user[active]" type="checkbox" value="false">
+             <label class="form-check-label" for="user_active">No</label>
+          </div>
+
+      build(:user, :colors, collection: ['Red', 'Blue'])
+      # => <div class="form-check">
+             <input name="user[colors]" type="hidden" value="false">
+             <input class="form-check-input" id="user_colors" name="user[colors]" type="checkbox" value="Red">
+             <label class="form-check-label" for="user_colors">Red</label>
+          </div>
+          <div class="form-check">
+             <input name="user[colors]" type="hidden" value="false">
+             <input class="form-check-input" id="user_colors" name="user[colors]" type="checkbox" value="Blue">
+             <label class="form-check-label" for="user_colors">Blue</label>
+          </div>
+  """
+  def build(form, field_name, options \\ []) do
+    # Ensure that the type is removed from options since it's going to be added by the Checkbox module.
+    {_type, options} = Keyword.pop(options, :type)
+    {collection, options} = Keyword.pop(options, :collection)
+
+    for item <- collection do
+      options = Keyword.merge(options, build_item_options(item))
+
+      Checkbox.build(form, field_name, options)
+    end
+  end
+
+  def build_item_options({value, label}), do: [label_text: label, value: value, checked_value: value]
+  def build_item_options(value), do: [label_text: value, value: value, checked_value: value]
+end

--- a/lib/bootstrap_form/input.ex
+++ b/lib/bootstrap_form/input.ex
@@ -12,6 +12,7 @@ defmodule BootstrapForm.Input do
   ]
 
   alias BootstrapForm.{
+    CollectionCheckboxes,
     Checkbox,
     EmailInput,
     PasswordInput,
@@ -30,7 +31,8 @@ defmodule BootstrapForm.Input do
     radio_button: RadioButton,
     select: Select,
     textarea: Textarea,
-    text_input: TextInput
+    text_input: TextInput,
+    collection_checkboxes: CollectionCheckboxes
   }
 
   @doc """

--- a/test/bootstrap_form/collection_checkboxes_test.exs
+++ b/test/bootstrap_form/collection_checkboxes_test.exs
@@ -1,0 +1,84 @@
+defmodule BootstrapForm.CollectionCheckboxesTest do
+  use ExUnit.Case
+  doctest BootstrapForm.CollectionCheckboxes
+
+  import Phoenix.HTML, only: [safe_to_string: 1]
+
+  alias BootstrapForm.CollectionCheckboxes
+
+  describe "build/3" do
+    test "generates a list of checkbox when the collection is a list of tuples" do
+      collection_input =
+        CollectionCheckboxes.build(
+          :user,
+          :active,
+          type: :collection_checkboxes,
+          collection: [{true, 'Yes'}, {false, "No"}]
+        )
+
+      expected =
+        ~s(<div class="form-check">) <>
+          ~s(<input name="user[active]" type="hidden" value="false">) <>
+          ~s(<input class="form-check-input" id="user_active" name="user[active]" type="checkbox" value="true">) <>
+          ~s(<label class="form-check-label" for="user_active">Yes</label>) <>
+        ~s(</div>) <>
+        ~s(<div class="form-check">) <>
+          ~s(<input name="user[active]" type="hidden" value="false">) <>
+          ~s(<input class="form-check-input" id="user_active" name="user[active]" type="checkbox" value="false">) <>
+          ~s(<label class="form-check-label" for="user_active">No</label>) <>
+        ~s(</div>)
+
+      assert collection_input |> Enum.map(&safe_to_string/1) |> Enum.join() == expected
+    end
+
+    test "generates a list of checkbox when the collection is a plain list" do
+      collection_input =
+        CollectionCheckboxes.build(
+          :user,
+          :colors,
+          type: :collection_checkboxes,
+          collection: ['Red','Blue']
+        )
+
+      expected =
+        ~s(<div class="form-check">) <>
+          ~s(<input name="user[colors]" type="hidden" value="false">) <>
+          ~s(<input class="form-check-input" id="user_colors" name="user[colors]" type="checkbox" value="Red">) <>
+          ~s(<label class="form-check-label" for="user_colors">Red</label>) <>
+        ~s(</div>) <>
+        ~s(<div class="form-check">) <>
+          ~s(<input name="user[colors]" type="hidden" value="false">) <>
+          ~s(<input class="form-check-input" id="user_colors" name="user[colors]" type="checkbox" value="Blue">) <>
+          ~s(<label class="form-check-label" for="user_colors">Blue</label>) <>
+        ~s(</div>)
+
+      assert collection_input |> Enum.map(&safe_to_string/1) |> Enum.join() == expected
+    end
+
+    test "supports custom options" do
+      collection_input =
+        CollectionCheckboxes.build(
+          :user,
+          :active,
+          type: :collection_checkboxes,
+          collection: [{true, 'Yes'}, {false, "No"}],
+          class: "checkbox-class",
+          wrapper_html: [class: "wrapper-class"]
+        )
+
+      expected =
+        ~s(<div class="form-check wrapper-class">) <>
+          ~s(<input name="user[active]" type="hidden" value="false">) <>
+          ~s(<input class="form-check-input checkbox-class" id="user_active" name="user[active]" type="checkbox" value="true">) <>
+          ~s(<label class="form-check-label" for="user_active">Yes</label>) <>
+        ~s(</div>) <>
+        ~s(<div class="form-check wrapper-class">) <>
+          ~s(<input name="user[active]" type="hidden" value="false">) <>
+          ~s(<input class="form-check-input checkbox-class" id="user_active" name="user[active]" type="checkbox" value="false">) <>
+          ~s(<label class="form-check-label" for="user_active">No</label>) <>
+        ~s(</div>)
+
+      assert collection_input |> Enum.map(&safe_to_string/1) |> Enum.join() == expected
+    end
+  end
+end


### PR DESCRIPTION
After this PR, clients are going to be able to render a list of checkboxes according to a collection.

Examples:

This new input:
```Elixir
input(:user, :active, type: :collection_checkboxes, collection: [{true, "Yes"}, {false, "No"}])
```

Generates the following HTML:
```HTML
<div class="form-check">
  <input name="user[active]" type="hidden" value="false">
  <input class="form-check-input" id="user_active" name="user[active]" type="checkbox" value="true">
  <label class="form-check-label" for="user_active">Yes</label>
</div>
<div class="form-check">
  <input name="user[active]" type="hidden" value="false">
  <input class="form-check-input" id="user_active" name="user[active]" type="checkbox" value="false">
  <label class="form-check-label" for="user_active">No</label>
</div>
```

It also supports a plain list:

```Elixir
input(:user, :colors, type: :collection_checkboxes, collection: ['Red', 'Blue'])
```

The output is pretty similar to the one showed above. The only difference is that the label and value are going to have the same value.

relates https://github.com/feliperenan/bootstrap_form/issues/6

### TODO
- [x] Add support to a list of tuples: `[{'value 1', 'option 1'}, {'value 2', 'option 2']}`
- [x] Add support to a plain list: `['option 1', 'option 2']` 