### PR TITLE
Add support to collection of radio buttons

### DIFF
--- a/lib/bootstrap_form.ex
+++ b/lib/bootstrap_form.ex
@@ -24,10 +24,13 @@ defmodule BootstrapForm do
           <%= submit "Submit", classL "btn btn-primary" %>
         <% end %>
 
-  It also supports a collection of checkboxes.
+  It also supports a collection of checkboxes and/or radio buttons.
 
         <%= input(form, :active, type: :collection_checkboxes, collection: [{true, "Yes"}, {false, "No"}]) %>
         <%= input(form, :colors, type: :collection_checkboxes, collection: ['Red', 'Blue']) %>
+
+        <%= input(form, :active, type: :collection_radio_buttons, collection: [{true, "Yes"}, {false, "No"}]) %>
+        <%= input(form, :colors, type: :collection_radio_buttons, collection: ['Red', 'Blue']) %>
 
   See `input/3` for the available options.
   """

--- a/lib/bootstrap_form/collection_radio_buttons.ex
+++ b/lib/bootstrap_form/collection_radio_buttons.ex
@@ -1,0 +1,54 @@
+defmodule BootstrapForm.CollectionRadioButtons do
+  @moduledoc false
+
+  alias BootstrapForm.{Input, RadioButton}
+
+  @behaviour Input
+
+  @doc """
+  Generate a list of bootstrap radio buttons according to the given options.
+
+  ## Custom options
+
+  collection: An array of items that will be used to render the radio buttons.
+
+  This function just interprets the given collection to render a radio button for each item. See the
+  `RadioButton` module for more info.
+
+  ## Examples
+
+      build(:user, :active, collection: [{true, "Yes"}, {false, "No"}])
+      # => <div class="form-check">
+             <input class="form-check-input" id="user_active" name="user[active]" type="radio" value="true">
+             <label class="form-check-label" for="user_active">Yes</label>
+          </div>
+          <div class="form-check">
+             <input class="form-check-input" id="user_active" name="user[active]" type="radio" value="false">
+             <label class="form-check-label" for="user_active">No</label>
+          </div>
+
+      build(:user, :colors, collection: ['Red', 'Blue'])
+      # => <div class="form-check">
+             <input class="form-check-input" id="user_colors" name="user[colors]" type="radio" value="Red">
+             <label class="form-check-label" for="user_colors">Red</label>
+          </div>
+          <div class="form-check">
+             <input class="form-check-input" id="user_colors" name="user[colors]" type="radio" value="Blue">
+             <label class="form-check-label" for="user_colors">Blue</label>
+          </div>
+  """
+  def build(form, field_name, options \\ []) do
+    # Ensure that the type is removed from options since it's going to be added by the RadioButton module.
+    {_type, options} = Keyword.pop(options, :type)
+    {collection, options} = Keyword.pop(options, :collection)
+
+    for item <- collection do
+      options = Keyword.merge(options, build_item_options(item))
+
+      RadioButton.build(form, field_name, options)
+    end
+  end
+
+  def build_item_options({value, label}), do: [label_text: label, value: value]
+  def build_item_options(value), do: [label_text: value, value: value]
+end

--- a/lib/bootstrap_form/input.ex
+++ b/lib/bootstrap_form/input.ex
@@ -13,6 +13,7 @@ defmodule BootstrapForm.Input do
 
   alias BootstrapForm.{
     CollectionCheckboxes,
+    CollectionRadioButtons,
     Checkbox,
     EmailInput,
     PasswordInput,
@@ -32,7 +33,8 @@ defmodule BootstrapForm.Input do
     select: Select,
     textarea: Textarea,
     text_input: TextInput,
-    collection_checkboxes: CollectionCheckboxes
+    collection_checkboxes: CollectionCheckboxes,
+    collection_radio_buttons: CollectionRadioButtons,
   }
 
   @doc """

--- a/test/bootstrap_form/collection_radio_buttons_test.exs
+++ b/test/bootstrap_form/collection_radio_buttons_test.exs
@@ -1,0 +1,78 @@
+defmodule BootstrapForm.CollectionRadioButtonsTest do
+  use ExUnit.Case
+  doctest BootstrapForm.CollectionRadioButtons
+
+  import Phoenix.HTML, only: [safe_to_string: 1]
+
+  alias BootstrapForm.CollectionRadioButtons
+
+  describe "build/3" do
+    test "generates a list of radio buttons when the collection is a list of tuples" do
+      collection_input =
+        CollectionRadioButtons.build(
+          :user,
+          :active,
+          type: :collection_radio_buttons,
+          collection: [{true, 'Yes'}, {false, "No"}]
+        )
+
+      expected =
+        ~s(<div class="form-check">) <>
+          ~s(<input class="form-check-input" id="user_active_true" name="user[active]" type="radio" value="true">) <>
+          ~s(<label class="form-check-label" for="user_active_true">Yes</label>) <>
+        ~s(</div>) <>
+        ~s(<div class="form-check">) <>
+          ~s(<input class="form-check-input" id="user_active_false" name="user[active]" type="radio" value="false">) <>
+          ~s(<label class="form-check-label" for="user_active_false">No</label>) <>
+        ~s(</div>)
+
+      assert collection_input |> Enum.map(&safe_to_string/1) |> Enum.join() == expected
+    end
+
+    test "generates a list of radio buttons when the collection is a plain list" do
+      collection_input =
+        CollectionRadioButtons.build(
+          :user,
+          :colors,
+          type: :collection_radio_buttons,
+          collection: ['Red','Blue']
+        )
+
+      expected =
+        ~s(<div class="form-check">) <>
+          ~s(<input class="form-check-input" id="user_colors_Red" name="user[colors]" type="radio" value="Red">) <>
+          ~s(<label class="form-check-label" for="user_colors_Red">Red</label>) <>
+        ~s(</div>) <>
+        ~s(<div class="form-check">) <>
+          ~s(<input class="form-check-input" id="user_colors_Blue" name="user[colors]" type="radio" value="Blue">) <>
+          ~s(<label class="form-check-label" for="user_colors_Blue">Blue</label>) <>
+        ~s(</div>)
+
+      assert collection_input |> Enum.map(&safe_to_string/1) |> Enum.join() == expected
+    end
+
+    test "supports custom options" do
+      collection_input =
+        CollectionRadioButtons.build(
+          :user,
+          :active,
+          type: :collection_radio_buttons,
+          collection: [{true, 'Yes'}, {false, "No"}],
+          class: "radio-class",
+          wrapper_html: [class: "wrapper-class"]
+        )
+
+      expected =
+        ~s(<div class="form-check wrapper-class">) <>
+          ~s(<input class="form-check-input radio-class" id="user_active_true" name="user[active]" type="radio" value="true">) <>
+          ~s(<label class="form-check-label" for="user_active_true">Yes</label>) <>
+        ~s(</div>) <>
+        ~s(<div class="form-check wrapper-class">) <>
+          ~s(<input class="form-check-input radio-class" id="user_active_false" name="user[active]" type="radio" value="false">) <>
+          ~s(<label class="form-check-label" for="user_active_false">No</label>) <>
+        ~s(</div>)
+
+      assert collection_input |> Enum.map(&safe_to_string/1) |> Enum.join() == expected
+    end
+  end
+end


### PR DESCRIPTION
After this PR, clients are going to be able to render a list of radio buttons according to a collection.

Examples:

This new input:
```Elixir
input(:user, :active, type: :collection_radio_buttons, collection: [{true, "Yes"}, {false, "No"}])
```

Generates the following HTML:
```HTML
<div class="form-check">
  <input class="form-check-input" id="user_active_true" name="user[active]" type="radio" value="true">
  <label class="form-check-label" for="user_active">Yes</label>
</div>
<div class="form-check">
  <input class="form-check-input" id="user_active_false" name="user[active]" type="radio" value="true">
  <label class="form-check-label" for="user_active">No</label>
</div>
```

Closes https://github.com/feliperenan/bootstrap_form/issues/6