### PR TITLE
Fix label for attribute when the input is a radio button

### DIFF
--- a/lib/bootstrap_form/radio_button.ex
+++ b/lib/bootstrap_form/radio_button.ex
@@ -1,7 +1,7 @@
 defmodule BootstrapForm.RadioButton do
   @moduledoc false
 
-  import Phoenix.HTML.Form, only: [radio_button: 4, label: 4]
+  import Phoenix.HTML.Form, only: [radio_button: 4, label: 4, input_id: 3]
 
   alias BootstrapForm.{Input, Wrapper}
 
@@ -29,11 +29,12 @@ defmodule BootstrapForm.RadioButton do
   @impl true
   def build(form, field_name, options \\ []) do
     input = Input.new(form, field_name, options, @default_classes)
+    label_for = input_id(form, field_name, input.value)
 
     Wrapper.build_tag(input) do
       [
         radio_button(form, field_name, input.value, input.options),
-        label(form, field_name, input.label_text, class: "form-check-label")
+        label(form, field_name, input.label_text, class: "form-check-label", for: label_for)
       ]
     end
   end

--- a/test/bootstrap_form/radio_button_test.exs
+++ b/test/bootstrap_form/radio_button_test.exs
@@ -11,7 +11,7 @@ defmodule BootstrapForm.RadioButtonTest do
       expected =
         ~s(<div class="form-check wrapper-class">) <>
           ~s(<input class="form-check-input" id="user_color_red" name="user[color]" type="radio" value="red">) <>
-          ~s(<label class="form-check-label" for="user_color">Red</label>) <>
+          ~s(<label class="form-check-label" for="user_color_red">Red</label>) <>
         ~s(</div>)
 
       input = RadioButton.build(:user, :color, value: "red", label_text: "Red", wrapper_html: [class: "wrapper-class"])


### PR DESCRIPTION
The label for attribute must be equal the input id.